### PR TITLE
Bump workflow version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Master
+* Allow workflow version < 2.0 in the Gemspec
+
 ## 0.0.2 (2014-08-26)
 
 * Fix naming error

--- a/workflow-sequel.gemspec
+++ b/workflow-sequel.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'workflow', '~> 1.1.0'
+  spec.add_runtime_dependency 'workflow', '>= 1.1.0'
   spec.add_runtime_dependency 'sequel', '~> 4.13'
 
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/workflow-sequel.gemspec
+++ b/workflow-sequel.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'workflow', '>= 1.1.0'
+  spec.add_runtime_dependency 'workflow', '< 2.0'
   spec.add_runtime_dependency 'sequel', '~> 4.13'
 
   spec.add_development_dependency 'bundler', '~> 1.6'


### PR DESCRIPTION
This patch just relaxes the dependency on workflow version 1.1. I've tested workflow-sequel manually with the newer version of workflow and everything seems to be functioning as expected.
