### PR TITLE
Use >= to allow sequel version 5.0 and higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased changes (2018-11-30)
+
+* Allow sequel version >= 5.0 in the Gemspec
+
 ## 0.1.0 (2016-04-24)
 
 * Allow workflow version < 2.0 in the Gemspec

--- a/workflow-sequel.gemspec
+++ b/workflow-sequel.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'workflow', '~> 1.1'
-  spec.add_runtime_dependency 'sequel', '~> 4.13'
+  spec.add_runtime_dependency 'sequel', '>= 4.13'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'

--- a/workflow-sequel.gemspec
+++ b/workflow-sequel.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'workflow', '~> 1.1'
-  spec.add_runtime_dependency 'sequel', '>= 4.13'
+  spec.add_runtime_dependency 'sequel', '>= 4.13', '< 6.0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Is this all that is required to fix #2 ?

Because this gem has no tests nor specs, I am simply testing its usage inside our application. Is there another way to know whether `workflow-sequel` needs to change any implementation for compatibility with Sequel 5.x?